### PR TITLE
fixed carrying capacity text when loading form scratch

### DIFF
--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -141,6 +141,7 @@ public class GameManager : MonoBehaviour
         if (!onMainMenu)
         {
             stolenManager.LoadStolenManager();
+            GameManager.instance.UpdateCarryingCapacityText();
             player.transform.position = GameObject.FindGameObjectWithTag("Respawn").transform.position;
             InventoriesUI.SetActive(true);
             mainMenu.SetActive(false);


### PR DESCRIPTION
Before we only updated the carrying capacity text when it was altered, but when playing a new game its value wouldn't be up to date, since it hasn't changed since it loaded, so now we also load it when loading the stolen manager.