### PR TITLE
Fixed throwing sound

### DIFF
--- a/Assets/Scripts/Managers/SoundManager.cs
+++ b/Assets/Scripts/Managers/SoundManager.cs
@@ -15,7 +15,7 @@ public class SoundManager : MonoBehaviour
         audioSource = GetComponent<AudioSource>();
 
         grabSFX = Resources.Load<AudioClip>("Audio/Sound FX/Grab");
-        throwSFX = Resources.Load<AudioClip>("Audio/Sound FX/Drop");
+        throwSFX = Resources.Load<AudioClip>("Audio/Sound FX/Throw");
         storeSFX = Resources.Load<AudioClip>("Audio/Sound FX/Store");
 
         clickSFX = Resources.Load<AudioClip>("Audio/Sound FX/Click");


### PR DESCRIPTION
The filename of the throwing sound was changed, but wasn't also changed when loading the sound in the `SoundManager`